### PR TITLE
docs: add Infra section to README (branch protection + sync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,14 @@ Phasing plan:
 ### CI Integration
 The lint / type gate runs in a dedicated workflow: `.github/workflows/lint-type.yml` (Ruff first, then Mypy). The general test workflow remains in `.github/workflows/ci.yml`.
 
+## 🧱 Infra
+
+### Branch protection
+Regler för `master` versioneras i `infra/bp.json`. Detta är source of truth för vilka status‑checks och skydd som gäller.
+
+### Sync
+Kör `tools/sync_branch_protection.py` eller följ instruktionerna i `docs/branch-protection.md` för att tillämpa reglerna via GitHub‑API.
+
 ## Architecture Decisions
 
 - See ADR index: `adr/README.md`


### PR DESCRIPTION
Adds a short Infra section to README covering:\n- Branch protection snapshot: infra/bp.json (source of truth)\n- Sync options: local script tools/sync_branch_protection.py or docs/branch-protection.md instructions