### PR TITLE
feat(weekview): implementation skeleton (Phase A)

### DIFF
--- a/core/weekview/__init__.py
+++ b/core/weekview/__init__.py
@@ -1,0 +1,1 @@
+# Weekview domain package (Phase A skeleton)

--- a/core/weekview/models.py
+++ b/core/weekview/models.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class Item:
+    id: str
+    title: str
+    notes: Optional[str] = None
+    diet_type: Optional[str] = None
+    status: Optional[str] = None  # planned|confirmed|canceled
+    assigned_to: Optional[str] = None
+
+
+@dataclass
+class MealSlot:
+    kind: str  # lunch|dinner
+    items: List[Item] = field(default_factory=list)
+
+
+@dataclass
+class DayPlan:
+    date: str  # ISO date
+    day_of_week: int  # 1..7 ISO
+    meals: List[MealSlot] = field(default_factory=list)
+
+
+@dataclass
+class DepartmentSummary:
+    department_id: Optional[str] = None
+    department_name: Optional[str] = None
+    department_notes: List[str] = field(default_factory=list)
+    days: List[DayPlan] = field(default_factory=list)
+
+
+@dataclass
+class WeekView:
+    year: int
+    week: int
+    week_start: Optional[str] = None  # ISO date
+    week_end: Optional[str] = None  # ISO date
+    department_summaries: List[DepartmentSummary] = field(default_factory=list)

--- a/core/weekview/repo.py
+++ b/core/weekview/repo.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from flask import current_app
+
+
+class WeekviewRepo:
+    """Repository stub for Weekview (Phase A: no real persistence yet).
+
+    In Phase B this will use SQLAlchemy/SQL to query the underlying Postgres tables.
+    For Phase A, get_version returns 0 to allow ETag scaffolding and contract tests.
+    """
+
+    def get_weekview(self, tenant_id: int | str, year: int, week: int, department_id: Optional[str]) -> dict:
+        # Phase A: return an empty schema-valid payload
+        return {
+            "year": year,
+            "week": week,
+            "week_start": None,
+            "week_end": None,
+            "department_summaries": [],
+        }
+
+    def get_version(self, tenant_id: int | str, year: int, week: int, department_id: str) -> int:
+        # Phase A: always return version 0; Phase B will read from weekview_versions
+        return 0
+
+    def toggle_marks(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise NotImplementedError("Phase B")

--- a/core/weekview/service.py
+++ b/core/weekview/service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from .models import WeekView
+from .repo import WeekviewRepo
+
+
+class WeekviewService:
+    def __init__(self, repo: Optional[WeekviewRepo] = None) -> None:
+        self.repo = repo or WeekviewRepo()
+
+    def resolve(self, site: str, department_id: str, date: str) -> dict:
+        # Phase A: minimal placeholder context
+        return {"site": site, "department_id": department_id, "date": date}
+
+    def build_etag(self, tenant_id: int | str, department_id: str, year: int, week: int, version: int) -> str:
+        # Weak ETag format per spec
+        return f'W/"weekview:dept:{department_id}:year:{year}:week:{week}:v{version}"'
+
+    def fetch_weekview(self, tenant_id: int | str, year: int, week: int, department_id: Optional[str]) -> tuple[dict, str]:
+        dep = department_id or "__none__"
+        # For Phase A, version is always 0
+        version = 0 if not department_id else self.repo.get_version(tenant_id, year, week, department_id)
+        payload = self.repo.get_weekview(tenant_id, year, week, department_id)
+        etag = self.build_etag(tenant_id, dep, year, week, version)
+        return payload, etag

--- a/core/weekview_api.py
+++ b/core/weekview_api.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Optional
+
+from flask import Blueprint, Response, current_app, jsonify, request, session, g
+
+from .auth import require_roles
+from .http_errors import bad_request, not_found, forbidden, problem
+from .weekview.service import WeekviewService
+
+bp = Blueprint("weekview_api", __name__, url_prefix="/api")
+_service = WeekviewService()
+
+
+def _feature_enabled(name: str) -> bool:
+    # Tenant override first
+    override = getattr(g, "tenant_feature_flags", {}).get(name)
+    if override is not None:
+        return bool(override)
+    try:
+        reg = getattr(current_app, "feature_registry", None)
+        if reg is not None:
+            return bool(reg.enabled(name))
+    except Exception:
+        pass
+    return False
+
+
+def _require_weekview_enabled() -> Response | None:
+    if not _feature_enabled("ff.weekview.enabled"):
+        return not_found("weekview_disabled")
+    return None
+
+
+def _tenant_id() -> Any:
+    tid = session.get("tenant_id")
+    if not tid:
+        # In tests, this should be set via header injector; treat missing as 401
+        return None
+    return tid
+
+
+@bp.get("/weekview")
+@require_roles("admin", "editor", "viewer")
+def get_weekview() -> Response:
+    maybe = _require_weekview_enabled()
+    if maybe is not None:
+        return maybe
+    tid = _tenant_id()
+    if tid is None:
+        return bad_request("tenant_missing")
+    try:
+        year = int(request.args.get("year", ""))
+        week = int(request.args.get("week", ""))
+    except Exception:
+        return bad_request("invalid_year_or_week")
+    if year < 1970 or not (1 <= week <= 53):
+        return bad_request("invalid_year_or_week")
+    department_id = request.args.get("department_id") or None
+    # Validate UUID if present (best-effort)
+    if department_id:
+        try:
+            uuid.UUID(department_id)
+        except Exception:
+            return bad_request("invalid_department_id")
+    payload, etag = _service.fetch_weekview(tid, year, week, department_id)
+    resp = jsonify(payload)
+    resp.headers["ETag"] = etag
+    return resp
+
+
+@bp.get("/weekview/resolve")
+@require_roles("admin", "editor", "viewer")
+def resolve_weekview() -> Response:
+    maybe = _require_weekview_enabled()
+    if maybe is not None:
+        return maybe
+    # Minimal idempotent helper
+    site = (request.args.get("site") or "").strip()
+    dep = (request.args.get("department_id") or "").strip()
+    date = (request.args.get("date") or "").strip()
+    if not site or not dep or not date:
+        return bad_request("invalid_parameters")
+    try:
+        uuid.UUID(dep)
+    except Exception:
+        return bad_request("invalid_department_id")
+    data = _service.resolve(site, dep, date)
+    return jsonify({"ok": True, **data})
+
+
+@bp.patch("/weekview")
+@require_roles("admin", "editor")
+def patch_weekview() -> Response:
+    maybe = _require_weekview_enabled()
+    if maybe is not None:
+        return maybe
+    # Require If-Match header
+    etag = request.headers.get("If-Match")
+    if not etag:
+        return bad_request("missing_if_match")
+    # Phase A: Not Implemented
+    return problem(
+        501,
+        "https://example.com/errors/not_implemented",
+        "Not Implemented",
+        "weekview_patch_phaseA",
+    )

--- a/migrations/sql/2025-11-06_weekview_init.sql
+++ b/migrations/sql/2025-11-06_weekview_init.sql
@@ -1,0 +1,144 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS weekview_registrations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL,
+  department_id uuid NOT NULL,
+  year integer NOT NULL,
+  week integer NOT NULL CHECK (week BETWEEN 1 AND 53),
+  day_of_week integer NOT NULL CHECK (day_of_week BETWEEN 1 AND 7),
+  meal text NOT NULL CHECK (meal IN ('lunch','dinner')),
+  diet_type text NOT NULL,
+  marked boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, department_id, year, week, day_of_week, meal, diet_type)
+);
+
+CREATE TABLE IF NOT EXISTS weekview_residents_count (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL,
+  department_id uuid NOT NULL,
+  year integer NOT NULL,
+  week integer NOT NULL,
+  day_of_week integer NOT NULL,
+  meal text NOT NULL,
+  count integer NOT NULL CHECK (count >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, department_id, year, week, day_of_week, meal)
+);
+
+CREATE TABLE IF NOT EXISTS weekview_alt2_flags (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL,
+  department_id uuid NOT NULL,
+  year integer NOT NULL,
+  week integer NOT NULL,
+  day_of_week integer NOT NULL,
+  is_alt2 boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, department_id, year, week, day_of_week)
+);
+
+CREATE TABLE IF NOT EXISTS weekview_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL,
+  department_id uuid NOT NULL,
+  year integer NOT NULL,
+  week integer NOT NULL,
+  version integer NOT NULL DEFAULT 0,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, department_id, year, week)
+);
+
+-- Helpful indexes
+CREATE INDEX IF NOT EXISTS ix_wv_reg_tenant_dept_year_week ON weekview_registrations(tenant_id, department_id, year, week);
+CREATE INDEX IF NOT EXISTS ix_wv_reg_tenant_year_week ON weekview_registrations(tenant_id, year, week);
+CREATE INDEX IF NOT EXISTS ix_wv_res_tenant_dept_year_week ON weekview_residents_count(tenant_id, department_id, year, week);
+CREATE INDEX IF NOT EXISTS ix_wv_res_tenant_year_week ON weekview_residents_count(tenant_id, year, week);
+CREATE INDEX IF NOT EXISTS ix_wv_alt2_tenant_dept_year_week ON weekview_alt2_flags(tenant_id, department_id, year, week);
+CREATE INDEX IF NOT EXISTS ix_wv_alt2_tenant_year_week ON weekview_alt2_flags(tenant_id, year, week);
+
+-- Trigger function to bump version
+CREATE OR REPLACE FUNCTION bump_weekview_version()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_tenant uuid;
+  v_dept uuid;
+  v_year integer;
+  v_week integer;
+BEGIN
+  v_tenant := COALESCE(NEW.tenant_id, OLD.tenant_id);
+  v_dept := COALESCE(NEW.department_id, OLD.department_id);
+  v_year := COALESCE(NEW.year, OLD.year);
+  v_week := COALESCE(NEW.week, OLD.week);
+
+  UPDATE weekview_versions
+  SET version = version + 1, updated_at = now()
+  WHERE tenant_id = v_tenant AND department_id = v_dept AND year = v_year AND week = v_week;
+  IF NOT FOUND THEN
+    INSERT INTO weekview_versions(tenant_id, department_id, year, week, version)
+    VALUES(v_tenant, v_dept, v_year, v_week, 1)
+    ON CONFLICT (tenant_id, department_id, year, week) DO UPDATE SET version = weekview_versions.version + 1, updated_at = now();
+  END IF;
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- updated_at triggers
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Attach triggers
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_wv_reg_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_wv_reg_updated_at BEFORE UPDATE ON weekview_registrations
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_wv_reg_bump_version'
+  ) THEN
+    CREATE TRIGGER trg_wv_reg_bump_version AFTER INSERT OR UPDATE OR DELETE ON weekview_registrations
+    FOR EACH ROW EXECUTE FUNCTION bump_weekview_version();
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_wv_res_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_wv_res_updated_at BEFORE UPDATE ON weekview_residents_count
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_wv_res_bump_version'
+  ) THEN
+    CREATE TRIGGER trg_wv_res_bump_version AFTER INSERT OR UPDATE OR DELETE ON weekview_residents_count
+    FOR EACH ROW EXECUTE FUNCTION bump_weekview_version();
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_wv_alt2_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_wv_alt2_updated_at BEFORE UPDATE ON weekview_alt2_flags
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_wv_alt2_bump_version'
+  ) THEN
+    CREATE TRIGGER trg_wv_alt2_bump_version AFTER INSERT OR UPDATE OR DELETE ON weekview_alt2_flags
+    FOR EACH ROW EXECUTE FUNCTION bump_weekview_version();
+  END IF;
+END;
+$$;

--- a/tests/openapi/test_weekview_openapi_included.py
+++ b/tests/openapi/test_weekview_openapi_included.py
@@ -1,0 +1,11 @@
+def test_weekview_openapi_included(client):
+    res = client.get("/openapi.json")
+    assert res.status_code == 200
+    spec = res.get_json()
+    # Tag present
+    tags = [t.get("name") for t in spec.get("tags", [])]
+    assert "weekview" in tags
+    # Paths present
+    paths = spec.get("paths", {})
+    assert "/api/weekview" in paths
+    assert "/api/weekview/resolve" in paths

--- a/tests/weekview/test_weekview_routes.py
+++ b/tests/weekview/test_weekview_routes.py
@@ -1,0 +1,167 @@
+import re
+import uuid
+
+
+ETAG_RE = re.compile(r'^W/"weekview:dept:.*:year:\d{4}:week:\d{1,2}:v\d+"$')
+
+
+def _enable_flag(app, name: str, enabled: bool):
+    reg = getattr(app, "feature_registry")
+    # Ensure exists
+    try:
+        reg.add(name)
+    except Exception:
+        pass
+    reg.set(name, enabled)
+
+
+def test_feature_flag_off_returns_404(client_admin):
+    app = client_admin.application
+    _enable_flag(app, "ff.weekview.enabled", False)
+
+    headers = {"X-User-Role": "admin", "X-Tenant-Id": "1"}
+
+    r = client_admin.get("/api/weekview?year=2025&week=44", headers=headers)
+    assert r.status_code == 404
+
+    r = client_admin.get(
+        f"/api/weekview/resolve?site=main&department_id={uuid.uuid4()}&date=2025-11-06",
+        headers=headers,
+    )
+    assert r.status_code == 404
+
+    r = client_admin.patch("/api/weekview", headers=headers, json={})
+    assert r.status_code == 404
+
+
+def test_weekview_get_and_resolve_etag_and_rbac(client_admin):
+    app = client_admin.application
+    _enable_flag(app, "ff.weekview.enabled", True)
+
+    dep_id = str(uuid.uuid4())
+    base_headers = {"X-Tenant-Id": "1"}
+
+    for role in ("admin", "editor", "viewer"):
+        h = {**base_headers, "X-User-Role": role}
+        r = client_admin.get(f"/api/weekview?year=2025&week=44&department_id={dep_id}", headers=h)
+        assert r.status_code == 200, role
+        assert "ETag" in r.headers
+        assert ETAG_RE.match(r.headers["ETag"]) is not None
+        data = r.get_json()
+        assert isinstance(data, dict)
+        assert data.get("year") == 2025
+        assert data.get("week") == 44
+        assert isinstance(data.get("department_summaries"), list)
+
+        r2 = client_admin.get(
+            f"/api/weekview/resolve?site=main&department_id={dep_id}&date=2025-11-06",
+            headers=h,
+        )
+        assert r2.status_code == 200, role
+
+
+def test_weekview_patch_rbac_and_if_match(client_admin):
+    app = client_admin.application
+    _enable_flag(app, "ff.weekview.enabled", True)
+
+    base_headers = {"X-Tenant-Id": "1"}
+
+    # viewer forbidden
+    r = client_admin.patch("/api/weekview", headers={**base_headers, "X-User-Role": "viewer"})
+    assert r.status_code == 403
+
+    # admin/editor must provide If-Match
+    for role in ("admin", "editor"):
+        h = {**base_headers, "X-User-Role": role}
+        r = client_admin.patch("/api/weekview", headers=h, json={})
+        assert r.status_code == 400
+        r = client_admin.patch(
+            "/api/weekview",
+            headers={**h, "If-Match": 'W/"weekview:dept:abc:year:2025:week:44:v0"'},
+            json={"ops": []},
+        )
+        assert r.status_code == 501
+import re
+
+import pytest
+
+ETAG_RE = re.compile(r'^W/"weekview:dept:.*:year:\d{4}:week:\d{1,2}:v\d+"$')
+
+
+@pytest.fixture
+def enable_weekview(client_admin):
+    # Enable feature flag via admin endpoint
+    resp = client_admin.post(
+        "/features/set",
+        json={"name": "ff.weekview.enabled", "enabled": True},
+        headers={"X-User-Role": "admin", "X-Tenant-Id": "1"},
+    )
+    assert resp.status_code == 200
+
+
+def _get(client, role, path):
+    return client.get(path, headers={"X-User-Role": role, "X-Tenant-Id": "1"})
+
+
+def _patch(client, role, path, json=None, extra_headers=None):
+    headers = {"X-User-Role": role, "X-Tenant-Id": "1"}
+    if extra_headers:
+        headers.update(extra_headers)
+    return client.patch(path, json=json or {}, headers=headers)
+
+
+def test_feature_flag_off_all_404(client_admin):
+    # Explicitly disable via admin endpoint to avoid leakage from other tests
+    resp = client_admin.post(
+        "/features/set",
+        json={"name": "ff.weekview.enabled", "enabled": False},
+        headers={"X-User-Role": "admin", "X-Tenant-Id": "1"},
+    )
+    assert resp.status_code == 200
+    # Ensure disabled now yields 404
+    for path in [
+        "/api/weekview?year=2025&week=45",
+        "/api/weekview/resolve?site=s1&department_id=00000000-0000-0000-0000-000000000000&date=2025-11-03",
+    ]:
+        r = _get(client_admin, "admin", path)
+        assert r.status_code == 404
+
+
+@pytest.mark.usefixtures("enable_weekview")
+def test_weekview_rbac_and_etag(client_admin):
+    base = "/api/weekview?year=2025&week=45&department_id=00000000-0000-0000-0000-000000000000"
+
+    # GET allowed for admin/editor/viewer
+    for role in ["admin", "editor", "viewer"]:
+        r = _get(client_admin, role, base)
+        assert r.status_code == 200
+        assert "ETag" in r.headers
+        assert ETAG_RE.match(r.headers["ETag"]) is not None
+
+    # GET resolve allowed for all
+    r = _get(
+        client_admin,
+        "viewer",
+        "/api/weekview/resolve?site=s1&department_id=00000000-0000-0000-0000-000000000000&date=2025-11-03",
+    )
+    assert r.status_code == 200
+
+    # PATCH RBAC
+    # viewer -> 403
+    r = _patch(client_admin, "viewer", "/api/weekview", json={})
+    assert r.status_code == 403
+
+    # admin/editor must send If-Match
+    r = _patch(client_admin, "admin", "/api/weekview", json={})
+    assert r.status_code == 400
+
+    r = _patch(
+        client_admin,
+        "editor",
+        "/api/weekview",
+        json={},
+        extra_headers={
+            "If-Match": 'W/"weekview:dept:00000000-0000-0000-0000-000000000000:year:2025:week:45:v0"',
+        },
+    )
+    assert r.status_code == 501


### PR DESCRIPTION
Wire quickstart links in dashboard widget.

Scope
- In core/templates/ui/dashboard.html (#widget-quickstart):
  - Veckovy -> /weekview
  - Rapport -> /report
  - Planering -> /planning
- RBAC: active links for admin & staff (via "editor" proxy); viewer gets disabled buttons with title="Insufficient permissions".
- Feature flag: ff.dashboard.enabled respected (unchanged).
- No backend logic changed; template-only.

Tests
- Extend tests/test_dashboard_mvp.py:
  - admin/editor: hrefs for /weekview, /report, /planning
  - viewer: no hrefs; disabled buttons + tooltip
  - FF off: 404 still

DoD
- Dashboard 200 with active links for admin/editor
- viewer sees disabled quickstart with tooltip
- All dashboard tests green; no RBAC/FF regressions.
