### PR TITLE
Hotfix: menu-choice PUT 500 on SQLAlchemy 2.x

### DIFF
--- a/core/menu_choice_api.py
+++ b/core/menu_choice_api.py
@@ -11,6 +11,7 @@ Weekend (sat/sun) does not allow Alt2 – returns 422 ProblemDetails.
 """
 
 from flask import Blueprint, request, jsonify
+from sqlalchemy import text
 
 from .auth import require_roles
 from .http_errors import bad_request, problem
@@ -143,7 +144,7 @@ def put_menu_choice():  # type: ignore[return-value]
     db = get_session()
     try:
         row = db.execute(
-            "SELECT site_id FROM departments WHERE id=:id", {"id": department_id}
+            text("SELECT site_id FROM departments WHERE id=:id"), {"id": department_id}
         ).fetchone()
         if not row:
             return bad_request("department_not_found")


### PR DESCRIPTION
Recreates earlier hotfix (supersedes prior PR #41) from a clean origin/master base to avoid merge conflicts.\n\nChange:\n- Wrap raw SELECT in sqlalchemy.text() inside PUT /menu-choice handler to satisfy SQLAlchemy 2.x execution API.\n\nValidation:\n- Focused tests: 7 menu-choice tests pass.\n- Full suite: 353 passed, 7 skipped.\n\nNext steps:\n1. Merge when CI green.\n2. Bump VERSION to 0.3.2 with CHANGELOG entry (hotfix + requirements cleanup).\n3. Tag v0.3.2, deploy, smoke, GitHub Release.\n\nSupersedes: Will close #41 after this opens.