### PR TITLE
fix(runtime): add whitenoise to requirements for WSGI static serving

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pytest==8.3.2
 pytest-cov==5.0.0
 openapi-spec-validator==0.7.1
 PyYAML>=6.0
+whitenoise>=6.5.0
 Flask==3.0.3
 SQLAlchemy==2.0.32
 alembic==1.13.2
@@ -20,6 +21,7 @@ pytest==8.3.2
 pytest-cov==5.0.0
 openapi-spec-validator==0.7.1
 PyYAML>=6.0
+whitenoise>=6.5.0
 ruff==0.6.3
 mypy==1.11.2
 gunicorn==22.0.0


### PR DESCRIPTION
Production boot failed with ModuleNotFoundError: 'whitenoise' from core/wsgi.py. Add whitenoise to requirements.txt to restore static handling via WhiteNoise.\n\n- Adds: \whitenoise>=6.5.0\\n- Affects: runtime only; no code changes.\n- Validated: CI should cover install; will redeploy after merge and run smoke.\n\nPlease prioritize merge to restore deployability.