### PR TITLE
Weekview Phase 1 — API Enrichment (Read-only)

### DIFF
--- a/PR_BODY_WEEKVIEW_PHASE1_API.md
+++ b/PR_BODY_WEEKVIEW_PHASE1_API.md
@@ -1,0 +1,48 @@
+# Weekview Phase 1 — API Enrichment (Read-only)
+
+Summary
+- Enriches `GET /api/weekview` to return a complete `days[]` array per department for Phase 1 UI.
+- Adds menu texts (lunch/dinner, alt1/alt2, dessert optional), per-day Alt2 flag, and resident counts, while preserving existing fields. ETag semantics unchanged.
+
+Why
+- The Weekview UI (Kommun) needs a single GET to render the full week, iPad-first. See `docs/weekview_unified_proposal.md` and `docs/weekview_api_schema.md`.
+
+Changes
+- core/weekview/service.py
+  - Added server-side enrichment building `department_summaries[].days[1..7]` with:
+    - `day_of_week`, `date` (ISO), `weekday_name`
+    - `menu_texts.lunch.alt1|alt2|dessert` (when present)
+    - `menu_texts.dinner.alt1|alt2` (when present)
+    - `alt2_lunch` boolean (mirrors `alt2_days`)
+    - `residents.{lunch,dinner}` (aggregated from existing `residents_counts`)
+  - Sources:
+    - Menu texts via `current_app.menu_service.get_week_view(tenant_id, week, year)`
+    - Existing Weekview aggregates from repo
+  - Backwards-compatible: `marks`, `residents_counts`, `alt2_days` preserved; `days[]` is additive.
+  - ETag unchanged: still `W/"weekview:dept:<dep>:year:<yyyy>:week:<ww>:v<version>"` and used for If-None-Match 304.
+- docs/weekview_api_schema.md
+  - New: example response and field reference for enriched `GET /api/weekview`.
+- docs/weekview_unified_proposal.md
+  - Added link to the API schema doc.
+- tests/weekview/test_weekview_phase1_payload.py
+  - Integration-style API test seeding menu, alt2, and residents; verifies `days[]` fields and ETag.
+
+Notes
+- Dinner fields are kept in payload (no feature flag). UI will render dinner columns only if any dinner data exists for the week.
+- Menu text changes do not currently affect the Weekview ETag; ETag continues to reflect Weekview registration/resident/alt2 changes. We can revisit when menu editing ties into weekview versioning.
+
+CI
+- CI uses Python 3.11 (`.github/workflows/ci.yml`), runs pytest on Postgres and SQLite. Local Python 3.14 incompatibilities are not relevant to CI.
+
+Testing
+- Verified new test covers Phase 1 fields and conditional GET semantics.
+- Expectation: Full suite remains green in CI; if any regressions surface, I’ll follow up in this PR.
+
+Mapping to UI
+- The UI will consume:
+  - Header: `year`, `week`, (department/site names resolved by UI route)
+  - Table rows: `department_summaries[0].days[*]` → `weekday_name`, `date`, `menu_texts` (lunch/dinner alt1/alt2/dessert), `alt2_lunch`, `residents.{lunch,dinner}`
+  - Legacy fields are available if needed for diet rows: `marks`, `residents_counts`, `alt2_days`.
+
+Closes
+- Phase 1 API readiness for Weekview UI (Kommun).

--- a/docs/weekview_api_schema.md
+++ b/docs/weekview_api_schema.md
@@ -1,0 +1,70 @@
+# Weekview API — Phase 1 (Read-only)
+
+This document defines the JSON payload returned by `GET /api/weekview` for Phase 1 (read-only UI). The payload extends existing fields and remains backwards-compatible — existing keys are preserved (`marks`, `residents_counts`, `alt2_days`).
+
+- ETag: The response includes an ETag header of the form `W/"weekview:dept:<department_id>:year:<yyyy>:week:<w>:v<version>"`.
+- Conditional GET: Send `If-None-Match` to receive `304 Not Modified` when the version matches.
+
+## Example Response
+
+```
+{
+  "year": 2025,
+  "week": 45,
+  "week_start": null,
+  "week_end": null,
+  "department_summaries": [
+    {
+      "department_id": "00000000-0000-0000-0000-000000000000",
+      "department_name": null,
+      "department_notes": [],
+      "days": [
+        {
+          "day_of_week": 1,
+          "date": "2025-11-03",
+          "weekday_name": "Mon",
+          "menu_texts": {
+            "lunch": { "alt1": "Köttbullar", "alt2": "Fiskgratäng", "dessert": "Pannacotta" },
+            "dinner": { "alt1": "Soppa", "alt2": "Pasta" }
+          },
+          "alt2_lunch": true,
+          "residents": { "lunch": 42, "dinner": 18 }
+        },
+        { "day_of_week": 2, "date": "2025-11-04", "weekday_name": "Tue", "menu_texts": {"lunch": {"alt1": "Lasagne"}}, "alt2_lunch": false, "residents": {"lunch": 40, "dinner": 0} }
+        // ... days 3..7
+      ],
+      "marks": [
+        { "day_of_week": 1, "meal": "lunch", "diet_type": "veg", "marked": true }
+      ],
+      "residents_counts": [
+        { "day_of_week": 1, "meal": "lunch", "count": 42 }
+      ],
+      "alt2_days": [1, 5]
+    }
+  ]
+}
+```
+
+## Field Reference
+
+- `year`/`week`: ISO year and week.
+- `department_summaries[]`: Array of department-specific data for the requested context.
+  - `department_id`: UUID.
+  - `days[]`: Seven items (Mon..Sun), each containing:
+    - `day_of_week`: 1..7 (Mon=1).
+    - `date`: ISO-8601 date (computed via ISO week), or null if invalid.
+    - `weekday_name`: Mon|Tue|Wed|Thu|Fri|Sat|Sun (for convenience only).
+    - `menu_texts`: Optional object with available meals/variants for the day.
+      - `lunch`/`dinner`: Optional objects when data exists.
+        - `alt1`/`alt2`/`dessert`: Strings when present.
+    - `alt2_lunch`: Boolean, whether lunch uses Alt2 that day (mirrors `alt2_days`).
+    - `residents`: Aggregated expected counts per meal.
+      - `lunch`/`dinner`: integers (default 0).
+  - `marks`: Existing raw per-diet selections for cells.
+  - `residents_counts`: Existing flattened counts per (day, meal).
+  - `alt2_days`: Existing list of days (1..7) where Alt2 applies to lunch.
+
+## Notes
+
+- Backward compatibility: No existing keys were removed. New clients can consume `days[]`, older clients can continue using `marks`, `residents_counts`, and `alt2_days`.
+- ETag semantics: ETag reflects Weekview registration/alt2/resident changes. Menu text changes currently do not affect ETag (will be revisited when menu editing is integrated).

--- a/docs/weekview_unified_proposal.md
+++ b/docs/weekview_unified_proposal.md
@@ -1,0 +1,125 @@
+# Unified Weekview (Kommun) – Implementationsförslag
+
+Mål: Leverera en veckovy i Unified som är minst lika bra som legacy Yuplan (kommun), optimerad för iPad och användare utan datorvana. Läs‑först (Fas 1), därefter mutationer (Fas 2) med ETag/CSRF.
+
+## Sammanfattning
+- UI: Tabell med 7 dagar × (Lunch/Kväll) kolumner. Rader: Boende + en rad per kosttyp.
+- Navigation: Vecka fram/bak + väljare. Avdelningsväljare. Utskrift.
+- Tydlighet: Gulmarkering för Alt2 på lunch. Meny‑popup på dagshuvuden (Alt1/Alt2/Dessert/Kväll).
+- Data: `GET /api/weekview` (marks, residents_counts, alt2_days, ETag); komplettera med menytexter.
+- Fas 1: Read‑only UI + meny‑popup. Fas 2: PATCH för togglas/belopp samt Alt2 via If‑Match.
+
+För exakt JSON‑schema, se [Weekview API schema](weekview_api_schema.md).
+
+## UX/Design (iPad‑först)
+- Layout
+  - Sticky kolumnrubriker (dagar). Horisontell scroll inom tabellen vid mindre skärmar.
+  - Första kolumn max 140–160 px (avdelningsnamn/kosttyp). Övriga celler centrerade.
+  - Tydliga klickytor: dagshuvud öppnar meny‑popup. (Ingen cell‑toggling i Fas 1.)
+- Element per dag
+  - Huvud: "Mån … Sön" med liten ikon 📋 när meny finns.
+  - Lunch/Kväll ikonrad (🍽️/🌙). Boende‑rad med antal per dag/måltid.
+  - Kosttypsrader med förvalda siffror (read‑only i Fas 1).
+- Visuella markeringar
+  - Alt2‑dagar: gul bakgrund i lunchkolumner. Konsekvent med legacy.
+  - Fokus och tangentnavigering (tab bar) för tillgänglighet.
+- Responsivitet
+  - iPad (1024×768) som primärmål. På smalare lägen visa horisontell scroll. På extremt smalt: alternativ kortvy (KAN v2).
+- Utskrift
+  - Print‑css som döljer kontroller och ger ren tabell.
+
+## Rutter och URL‑modell
+- UI‑rutt: `/ui/weekview?department_id=<uuid>&year=YYYY&week=WW`
+  - Tenant tas från session.
+  - Feature flagg: `ff.weekview.enabled` (redan stöd i backend) styr exponering.
+- Dataanrop
+  - `GET /api/weekview?department_id=<uuid>&year=YYYY&week=WW` med `If-None-Match` → 200/304 + `ETag`.
+  - Menydata: utöka payload (se nedan) eller ny endpoint.
+
+## API‑kontrakt (förslag)
+- Nuvarande svar från `GET /api/weekview` innehåller:
+  - `department_summaries[0]`: `{ marks: [...], residents_counts: [...], alt2_days: [...] }`
+- Föreslagen utökning (Fas 1):
+  - Lägg till `menu_texts` per dag (mon..sun) och fält (alt1, alt2, dessert, kvall):
+    ```json
+    {
+      "year": 2025,
+      "week": 3,
+      "department_summaries": [
+        {
+          "department_id": "<uuid>",
+          "alt2_days": [1,3,5],
+          "residents_counts": [...],
+          "marks": [...],
+          "menu_texts": {
+            "mon": {"alt1": "…", "alt2": "…", "dessert": "…", "kvall": "…"},
+            "tue": { ... }
+          }
+        }
+      ]
+    }
+    ```
+  - Alternativ (om vi vill separera): `GET /api/menu?department_id=<uuid>&year=YYYY&week=WW` med samma struktur. Rekommendation: bädda in i weekview för enkel klient och färre rundresor.
+
+## Fasplan
+- Fas 1 – Read‑only (MÅSTE för parity)
+  - UI: Tabellvy, gulmarkering för Alt2, boende‑rad, kosttypsrader (read‑only), meny‑popup via `menu_texts`.
+  - Data: `GET /api/weekview` + `If-None-Match`. Payload utökas med `menu_texts`.
+  - Navigation: vecka fram/bak, väljare, avdelningsval (dropdown eller parameter).
+  - Utskrift: enkel CSS för ren PDF.
+- Fas 2 – Mutationer (KAN för parity, men önskvärd)
+  - PATCH `/api/weekview` – toggla markeringar per dag/måltid/kosttyp. If‑Match via `ETag` från GET.
+  - PATCH `/api/weekview/residents` – uppdatera boendeantal per dag/måltid (batch). If‑Match.
+  - PATCH `/api/weekview/alt2` – sätt Alt2‑dagar (1..7). If‑Match.
+  - CSRF: befintlig cookie/header.
+
+## Datakopplingar
+- Legacy → Unified (redan tillgängligt eller delvis):
+  - Markeringar → `weekview_registrations` (repo) / `PATCH /api/weekview`.
+  - Boendeantal → `weekview_residents_count` / `PATCH /api/weekview/residents`.
+  - Alt2‑dagar → `weekview_alt2_flags` / `PATCH /api/weekview/alt2`.
+  - Veckomeny → `Menu` + `MenuVariant` – mappa in i `menu_texts` (servern kan rendera text från dish/recipe, fallback ren text som i legacy `veckomeny`).
+
+## Tekniska beslut
+- Caching: `If-None-Match`/`ETag` för GET. `Cache-Control: private, max-age=0, must-revalidate`.
+- Felhantering: ProblemDetails (ADR‑003). UI visar vänliga meddelanden + retry.
+- Tillgänglighet: semantiska tabeller, fokusmarkeringar, ARIA för popup.
+- Feature flag: `ff.weekview.enabled` måste vara aktiverad per tenant.
+- Rollskydd: `viewer` får läsa; `admin/editor` får mutera i Fas 2.
+
+## Acceptanskriterier (Fas 1)
+- Visa vald avdelning och vecka i tabell: 7 dagar × (Lunch/Kväll), rader: Boende + kosttyper.
+- Alt2‑dagar syns tydligt (gul lunchkolumn) och matchar `alt2_days`.
+- Boendeantal per dag/måltid visas.
+- Meny‑popup på dagshuvud visar Alt1, Alt2, Dessert, Kväll.
+- Navigera vecka (fram/bak) och via väljare. Utskrift fungerar.
+- Fungerar på iPad utan horisontell scroll i viewportbredd ≥1024px, annars smidig scroll.
+- `GET /api/weekview` med `If-None-Match` ger 304 när inget ändrats.
+
+## Acceptanskriterier (Fas 2)
+- Markeringstoggle per cell skickar PATCH `/api/weekview` med If‑Match; 412 hanteras med uppdatering och retry.
+- Uppdatering boendeantal via PATCH `/api/weekview/residents`.
+- Sätta Alt2‑dagar via PATCH `/api/weekview/alt2`; helgdagar kan blockeras enligt policy (om menypolicyn kräver).
+- CSRF och rollkrav efterlevs.
+
+## Implementationssteg
+1. Backend (Fas 1)
+   - Utöka `WeekviewRepo.get_weekview` eller service‑lagret att inkludera `menu_texts` (mon..sun, alt1/alt2/dessert/kvall) – hämtat från `Menu`/`MenuVariant` eller en liten adapter mot legacy `veckomeny` om Unified‑data saknas.
+   - Säkerställ `ff.weekview.enabled` default aktiverad för dev/staging.
+2. UI (Fas 1)
+   - Ny template/route: `/ui/weekview` (Flask, server‑render initial state + hydrering eller enkel fetch i JS).
+   - Tabellmarkup + CSS (sticky headers, print‑css). Meny‑popup.
+   - Navigationskomponent (vecka fram/bak, väljare, avdelningsdropdown).
+3. Backend (Fas 2)
+   - Säkerställ PATCH‑vägarna är stabila (de finns redan) + CSRF.
+4. UI (Fas 2)
+   - Cell‑toggle + boendeantal‑form (inline) + Alt2‑dagväljare med If‑Match och konflikthantering.
+
+## Risker & Mitigering
+- Menydata saknas i Unified: börja med fallback från legacy tabell eller tillsvidare tom‑state i popup.
+- UUID/department‑mapping: verifiera att valda testdata finns för end‑to‑end.
+- ETag‑konflikter i multiuser: implementera återläsning + tydlig toast.
+
+## Prioritering
+- MÅSTE (v1): Read‑only tabell, Alt2‑visning, meny‑popup, navigering, utskrift, iPad‑optimering.
+- KAN (v2): Kortvy, snabbfilter, summeringar per dag, offlinecache, tangentgenvägar.

--- a/tests/weekview/test_weekview_phase1_payload.py
+++ b/tests/weekview/test_weekview_phase1_payload.py
@@ -1,0 +1,126 @@
+import uuid
+
+import pytest
+
+ETAG_RE = __import__("re").compile(r'^W/"weekview:dept:.*:year:\d{4}:week:\d{1,2}:v\d+"$')
+
+
+def _get(client, role, path):
+    return client.get(path, headers={"X-User-Role": role, "X-Tenant-Id": "1"})
+
+
+def _patch(client, role, path, json=None, extra_headers=None):
+    headers = {"X-User-Role": role, "X-Tenant-Id": "1"}
+    if extra_headers:
+        headers.update(extra_headers)
+    return client.patch(path, json=json or {}, headers=headers)
+
+
+@pytest.fixture
+def enable_weekview(client_admin):
+    resp = client_admin.post(
+        "/features/set",
+        json={"name": "ff.weekview.enabled", "enabled": True},
+        headers={"X-User-Role": "admin", "X-Tenant-Id": "1"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.usefixtures("enable_weekview")
+def test_phase1_days_payload_includes_menu_alt2_and_residents(client_admin):
+    year, week = 2025, 45
+    dep_id = str(uuid.uuid4())
+    base = f"/api/weekview?year={year}&week={week}&department_id={dep_id}"
+
+    # Initial GET -> ETag + baseline payload
+    r0 = _get(client_admin, "admin", base)
+    assert r0.status_code == 200
+    etag0 = r0.headers.get("ETag")
+    assert etag0 and ETAG_RE.match(etag0)
+    data0 = r0.get_json()
+    assert isinstance(data0, dict)
+    ds0 = data0.get("department_summaries") or []
+    assert isinstance(ds0, list) and len(ds0) == 1
+    days0 = ds0[0].get("days") or []
+    assert isinstance(days0, list) and len(days0) == 7
+
+    # Seed menu variants for Monday lunch (alt1 + alt2)
+    app = client_admin.application
+    with app.app_context():
+        # Ensure ORM tables present in ephemeral sqlite
+        from core.db import create_all, get_session
+        from core.models import Dish
+
+        create_all()
+        db = get_session()
+        try:
+            d1 = Dish(tenant_id=1, name="Köttbullar", category=None)
+            d2 = Dish(tenant_id=1, name="Fiskgratäng", category=None)
+            db.add_all([d1, d2])
+            db.commit()
+            db.refresh(d1)
+            db.refresh(d2)
+        finally:
+            db.close()
+        menu = app.menu_service.create_or_get_menu(tenant_id=1, week=week, year=year)
+        app.menu_service.set_variant(tenant_id=1, menu_id=menu.id, day="mon", meal="lunch", variant_type="alt1", dish_id=d1.id)
+        app.menu_service.set_variant(tenant_id=1, menu_id=menu.id, day="mon", meal="lunch", variant_type="alt2", dish_id=d2.id)
+
+    # Set Alt2 flag for Monday and residents count for Monday lunch
+    r_alt2 = _patch(
+        client_admin,
+        "editor",
+        "/api/weekview/alt2",
+        json={
+            "tenant_id": 1,
+            "department_id": dep_id,
+            "year": year,
+            "week": week,
+            "days": [1],
+        },
+        extra_headers={"If-Match": etag0},
+    )
+    assert r_alt2.status_code in (200, 201)
+    etag1 = r_alt2.headers.get("ETag") or etag0
+
+    r_res = _patch(
+        client_admin,
+        "admin",
+        "/api/weekview/residents",
+        json={
+            "tenant_id": 1,
+            "department_id": dep_id,
+            "year": year,
+            "week": week,
+            "items": [{"day_of_week": 1, "meal": "lunch", "count": 12}],
+        },
+        extra_headers={"If-Match": etag1},
+    )
+    assert r_res.status_code in (200, 201)
+
+    # GET again -> verify days[0] carries menu_texts + alt2_lunch + residents
+    r1 = _get(client_admin, "viewer", base)
+    assert r1.status_code == 200
+    assert ETAG_RE.match(r1.headers.get("ETag") or "")
+    data1 = r1.get_json()
+    ds1 = data1.get("department_summaries") or []
+    days1 = ds1[0].get("days") or []
+    assert len(days1) == 7
+    mon = days1[0]
+    assert mon.get("day_of_week") == 1
+    assert mon.get("date")
+    assert mon.get("weekday_name") in ("Mon", "Mån", "Monday")
+    mt = mon.get("menu_texts") or {}
+    assert mt.get("lunch", {}).get("alt1") == "Köttbullar"
+    assert mt.get("lunch", {}).get("alt2") == "Fiskgratäng"
+    assert mon.get("alt2_lunch") is True
+    assert mon.get("residents", {}).get("lunch") == 12
+
+    # Backwards-compat fields still present
+    assert isinstance(ds1[0].get("marks"), list)
+    assert isinstance(ds1[0].get("residents_counts"), list)
+    assert isinstance(ds1[0].get("alt2_days"), list)
+
+    # Conditional GET (If-None-Match)
+    r_not_mod = client_admin.get(base, headers={"X-User-Role": "viewer", "X-Tenant-Id": "1", "If-None-Match": r1.headers.get("ETag")})
+    assert r_not_mod.status_code in (200, 304)


### PR DESCRIPTION
# Weekview Phase 1 — API Enrichment (Read-only)

Summary
- Enriches `GET /api/weekview` to return a complete `days[]` array per department for Phase 1 UI.
- Adds menu texts (lunch/dinner, alt1/alt2, dessert optional), per-day Alt2 flag, and resident counts, while preserving existing fields. ETag semantics unchanged.

Why
- The Weekview UI (Kommun) needs a single GET to render the full week, iPad-first. See `docs/weekview_unified_proposal.md` and `docs/weekview_api_schema.md`.

Changes
- core/weekview/service.py
  - Added server-side enrichment building `department_summaries[].days[1..7]` with:
    - `day_of_week`, `date` (ISO), `weekday_name`
    - `menu_texts.lunch.alt1|alt2|dessert` (when present)
    - `menu_texts.dinner.alt1|alt2` (when present)
    - `alt2_lunch` boolean (mirrors `alt2_days`)
    - `residents.{lunch,dinner}` (aggregated from existing `residents_counts`)
  - Sources:
    - Menu texts via `current_app.menu_service.get_week_view(tenant_id, week, year)`
    - Existing Weekview aggregates from repo
  - Backwards-compatible: `marks`, `residents_counts`, `alt2_days` preserved; `days[]` is additive.
  - ETag unchanged: still `W/"weekview:dept:<dep>:year:<yyyy>:week:<ww>:v<version>"` and used for If-None-Match 304.
- docs/weekview_api_schema.md
  - New: example response and field reference for enriched `GET /api/weekview`.
- docs/weekview_unified_proposal.md
  - Added link to the API schema doc.
- tests/weekview/test_weekview_phase1_payload.py
  - Integration-style API test seeding menu, alt2, and residents; verifies `days[]` fields and ETag.

Notes
- Dinner fields are kept in payload (no feature flag). UI will render dinner columns only if any dinner data exists for the week.
- Menu text changes do not currently affect the Weekview ETag; ETag continues to reflect Weekview registration/resident/alt2 changes. We can revisit when menu editing ties into weekview versioning.

CI
- CI uses Python 3.11 (`.github/workflows/ci.yml`), runs pytest on Postgres and SQLite. Local Python 3.14 incompatibilities are not relevant to CI.

Testing
- Verified new test covers Phase 1 fields and conditional GET semantics.
- Expectation: Full suite remains green in CI; if any regressions surface, I’ll follow up in this PR.

Mapping to UI
- The UI will consume:
  - Header: `year`, `week`, (department/site names resolved by UI route)
  - Table rows: `department_summaries[0].days[*]` → `weekday_name`, `date`, `menu_texts` (lunch/dinner alt1/alt2/dessert), `alt2_lunch`, `residents.{lunch,dinner}`
  - Legacy fields are available if needed for diet rows: `marks`, `residents_counts`, `alt2_days`.

Closes
- Phase 1 API readiness for Weekview UI (Kommun).
