### PR TITLE
Weekview UI Phase 1 — Read-only

### DIFF
--- a/core/ui_blueprint.py
+++ b/core/ui_blueprint.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from flask import Blueprint, render_template, session
+from flask import Blueprint, render_template, session, request, jsonify
+from sqlalchemy import text
 
 from .auth import require_roles
 from .db import get_session
 from .models import Note, Task, User
+from .weekview.service import WeekviewService
 
 ui_bp = Blueprint("ui", __name__, template_folder="templates", static_folder="static")
 
@@ -53,3 +55,90 @@ def workspace_ui():
         return render_template("ui/notes_tasks.html", notes=notes, tasks=tasks_view)
     finally:
         db.close()
+
+
+@ui_bp.get("/ui/weekview")
+@require_roles(*SAFE_UI_ROLES)
+def weekview_ui():
+    # Validate query params
+    site_id = (request.args.get("site_id") or "").strip()
+    department_id = (request.args.get("department_id") or "").strip()
+    try:
+        year = int(request.args.get("year", ""))
+        week = int(request.args.get("week", ""))
+    except Exception:
+        return jsonify({"error": "bad_request", "message": "Invalid year/week"}), 400
+    if year < 2000 or year > 2100:
+        return jsonify({"error": "bad_request", "message": "Invalid year"}), 400
+    if week < 1 or week > 53:
+        return jsonify({"error": "bad_request", "message": "Invalid week"}), 400
+
+    # Resolve names (sites/departments)
+    db = get_session()
+    try:
+        site_name = None
+        dep_name = None
+        if site_id:
+            row = db.execute(text("SELECT name FROM sites WHERE id = :id"), {"id": site_id}).fetchone()
+            site_name = row[0] if row else None
+        if department_id:
+            row = db.execute(
+                text("SELECT name FROM departments WHERE id = :id"), {"id": department_id}
+            ).fetchone()
+            dep_name = row[0] if row else None
+        if not site_name or not dep_name:
+            return jsonify({"error": "not_found", "message": "Site or department not found"}), 404
+    finally:
+        db.close()
+
+    # Fetch enriched weekview payload via service (no extra SQL here)
+    tid = session.get("tenant_id")
+    if not tid:
+        return jsonify({"error": "bad_request", "message": "Missing tenant"}), 400
+    svc = WeekviewService()
+    payload, _etag = svc.fetch_weekview(tid, year, week, department_id)
+    summaries = payload.get("department_summaries") or []
+    if not summaries:
+        vm = {
+            "site_name": site_name,
+            "department_name": dep_name,
+            "year": year,
+            "week": week,
+            "has_dinner": False,
+            "days": [],
+        }
+        return render_template("ui/weekview.html", vm=vm)
+    days = summaries[0].get("days") or []
+
+    # Build DayVM list
+    day_vms = []
+    has_dinner = False
+    for d in days:
+        mt = d.get("menu_texts") or {}
+        lunch = mt.get("lunch", {}) if isinstance(mt, dict) else {}
+        dinner = mt.get("dinner", {}) if isinstance(mt, dict) else {}
+        day_vm = {
+            "date": d.get("date"),
+            "weekday_name": d.get("weekday_name"),
+            "lunch_alt1": lunch.get("alt1"),
+            "lunch_alt2": lunch.get("alt2"),
+            "lunch_dessert": lunch.get("dessert"),
+            "dinner_alt1": dinner.get("alt1"),
+            "dinner_alt2": dinner.get("alt2"),
+            "alt2_lunch": bool(d.get("alt2_lunch")),
+            "residents_lunch": (d.get("residents", {}) or {}).get("lunch", 0),
+            "residents_dinner": (d.get("residents", {}) or {}).get("dinner", 0),
+        }
+        if day_vm["dinner_alt1"] or day_vm["dinner_alt2"]:
+            has_dinner = True
+        day_vms.append(day_vm)
+
+    vm = {
+        "site_name": site_name,
+        "department_name": dep_name,
+        "year": year,
+        "week": week,
+        "has_dinner": has_dinner,
+        "days": day_vms,
+    }
+    return render_template("ui/weekview.html", vm=vm)

--- a/templates/ui/weekview.html
+++ b/templates/ui/weekview.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% block title %}Weekview{% endblock %}
+{% block content %}
+<style>
+  .weekview-header { font-size: 1.25rem; margin: 0.5rem 0 1rem; }
+  .weekview-table { width: 100%; border-collapse: collapse; table-layout: fixed; }
+  .weekview-table th, .weekview-table td { border: 1px solid #e2e2e2; padding: 8px; vertical-align: top; }
+  .weekview-table th { background: #f7f7f7; text-align: left; }
+  .alt2-gul { background: #fff7bf; }
+  .subtle { color: #666; font-size: 0.875rem; }
+  .nav { margin: 0.5rem 0 1rem; }
+  .nav a { margin-right: 1rem; text-decoration: none; }
+</style>
+
+<div class="weekview-header">
+  {% if vm.days and vm.days|length > 0 %}
+    Vecka {{ vm.week }} – {{ vm.department_name }}, {{ vm.site_name }}
+  {% else %}
+    Vecka {{ vm.week }} – {{ vm.department_name }}, {{ vm.site_name }}
+  {% endif %}
+</div>
+
+{% set q = request.args %}
+{% set prev_week = (vm.week - 1) if vm.week > 1 else 53 %}
+{% set prev_year = (vm.year if vm.week > 1 else vm.year - 1) %}
+{% set next_week = (vm.week + 1) if vm.week < 53 else 1 %}
+{% set next_year = (vm.year if vm.week < 53 else vm.year + 1) %}
+<div class="nav">
+  <a href="/ui/weekview?site_id={{ q.get('site_id','') }}&department_id={{ q.get('department_id','') }}&year={{ prev_year }}&week={{ prev_week }}">« Föregående vecka</a>
+  <a href="/ui/weekview?site_id={{ q.get('site_id','') }}&department_id={{ q.get('department_id','') }}&year={{ next_year }}&week={{ next_week }}">Nästa vecka »</a>
+</div>
+
+{% if vm.days and vm.days|length > 0 %}
+<table class="weekview-table">
+  <thead>
+    <tr>
+      <th style="width:18%">Dag</th>
+      <th style="width:16%">Lunch Alt 1</th>
+      <th style="width:16%">Lunch Alt 2</th>
+      <th style="width:12%">Dessert</th>
+      {% if vm.has_dinner %}
+      <th style="width:16%">Middag Alt 1</th>
+      <th style="width:16%">Middag Alt 2</th>
+      {% endif %}
+      <th style="width:6%">Boende</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for d in vm.days %}
+      <tr>
+        <td>
+          <div><strong>{{ d.weekday_name }}</strong></div>
+          <div class="subtle">{{ d.date }}</div>
+        </td>
+        <td>{{ d.lunch_alt1 or '' }}</td>
+        <td class="{% if d.alt2_lunch %}alt2-gul{% endif %}">{{ d.lunch_alt2 or '' }}</td>
+        <td>{{ d.lunch_dessert or '' }}</td>
+        {% if vm.has_dinner %}
+        <td>{{ d.dinner_alt1 or '' }}</td>
+        <td>{{ d.dinner_alt2 or '' }}</td>
+        {% endif %}
+        <td>
+          <div class="subtle">L {{ d.residents_lunch or 0 }}</div>
+          {% if vm.has_dinner %}
+          <div class="subtle">M {{ d.residents_dinner or 0 }}</div>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+  <div class="subtle">Ingen meny hittades för vecka {{ vm.week }}.</div>
+{% endif %}
+{% endblock %}

--- a/tests/ui/test_weekview_ui_phase1.py
+++ b/tests/ui/test_weekview_ui_phase1.py
@@ -1,0 +1,145 @@
+import uuid
+
+import pytest
+
+ETAG_RE = __import__("re").compile(r'^W/"weekview:dept:.*:year:\d{4}:week:\d{1,2}:v\d+"$')
+
+
+def _h(role):
+    return {"X-User-Role": role, "X-Tenant-Id": "1"}
+
+
+@pytest.fixture
+def enable_weekview(client_admin):
+    resp = client_admin.post(
+        "/features/set",
+        json={"name": "ff.weekview.enabled", "enabled": True},
+        headers=_h("admin"),
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.usefixtures("enable_weekview")
+def test_weekview_ui_renders_header_menu_and_alt2(client_admin):
+    app = client_admin.application
+    site_id = str(uuid.uuid4())
+    dep_id = str(uuid.uuid4())
+    year, week = 2025, 45
+
+    # Seed sites/departments and dishes/menu
+    from core.db import create_all, get_session
+    from sqlalchemy import text
+    from core.models import Dish
+
+    with app.app_context():
+        create_all()
+        db = get_session()
+        try:
+            db.execute(text("INSERT INTO sites(id, name, version) VALUES(:i,:n,0) ON CONFLICT(id) DO NOTHING"), {"i": site_id, "n": "Varberg"})
+            db.execute(text("INSERT INTO departments(id, site_id, name, resident_count_mode, resident_count_fixed, version) VALUES(:i,:s,:n,'fixed',0,0) ON CONFLICT(id) DO NOTHING"), {"i": dep_id, "s": site_id, "n": "Avd 1"})
+            db.commit()
+            # Dishes
+            d1 = Dish(tenant_id=1, name="Köttbullar", category=None)
+            d2 = Dish(tenant_id=1, name="Fiskgratäng", category=None)
+            d3 = Dish(tenant_id=1, name="Vaniljpudding", category=None)
+            d4 = Dish(tenant_id=1, name="Soppa", category=None)
+            db.add_all([d1, d2, d3, d4])
+            db.commit()
+            db.refresh(d1); db.refresh(d2); db.refresh(d3); db.refresh(d4)
+            menu = app.menu_service.create_or_get_menu(tenant_id=1, week=week, year=year)
+            # Monday lunch alt1/alt2/dessert
+            app.menu_service.set_variant(tenant_id=1, menu_id=menu.id, day="mon", meal="lunch", variant_type="alt1", dish_id=d1.id)
+            app.menu_service.set_variant(tenant_id=1, menu_id=menu.id, day="mon", meal="lunch", variant_type="alt2", dish_id=d2.id)
+            app.menu_service.set_variant(tenant_id=1, menu_id=menu.id, day="mon", meal="lunch", variant_type="dessert", dish_id=d3.id)
+            # Tuesday dinner alt1
+            app.menu_service.set_variant(tenant_id=1, menu_id=menu.id, day="tue", meal="dinner", variant_type="alt1", dish_id=d4.id)
+        finally:
+            db.close()
+
+    # Get baseline ETag then set alt2 + residents
+    base = f"/api/weekview?year={year}&week={week}&department_id={dep_id}"
+    r0 = client_admin.get(base, headers=_h("admin"))
+    assert r0.status_code == 200 and ETAG_RE.match(r0.headers.get("ETag") or "")
+    etag0 = r0.headers.get("ETag")
+
+    r_alt2 = client_admin.patch(
+        "/api/weekview/alt2",
+        json={"tenant_id": 1, "department_id": dep_id, "year": year, "week": week, "days": [1]},
+        headers={**_h("editor"), "If-Match": etag0},
+    )
+    assert r_alt2.status_code in (200, 201)
+    etag1 = r_alt2.headers.get("ETag") or etag0
+
+    r_res = client_admin.patch(
+        "/api/weekview/residents",
+        json={
+            "tenant_id": 1,
+            "department_id": dep_id,
+            "year": year,
+            "week": week,
+            "items": [
+                {"day_of_week": 1, "meal": "lunch", "count": 11},
+                {"day_of_week": 2, "meal": "dinner", "count": 7},
+            ],
+        },
+        headers={**_h("admin"), "If-Match": etag1},
+    )
+    assert r_res.status_code in (200, 201)
+
+    # Render UI
+    r_ui = client_admin.get(
+        f"/ui/weekview?site_id={site_id}&department_id={dep_id}&year={year}&week={week}",
+        headers=_h("admin"),
+    )
+    assert r_ui.status_code == 200
+    html = r_ui.get_data(as_text=True)
+    # Header
+    assert f"Vecka {week} – Avd 1, Varberg" in html
+    # Menu
+    assert "Köttbullar" in html and "Fiskgratäng" in html and "Vaniljpudding" in html
+    # Alt2 highlight present on lunch alt2 cell
+    assert "alt2-gul" in html
+    # Dinner columns present (we added a dinner dish on Tue)
+    assert "Middag Alt 1" in html
+
+
+@pytest.mark.usefixtures("enable_weekview")
+def test_weekview_ui_no_dinner_hides_columns(client_admin):
+    app = client_admin.application
+    site_id = str(uuid.uuid4())
+    dep_id = str(uuid.uuid4())
+    year, week = 2025, 46
+
+    from core.db import create_all, get_session
+    from sqlalchemy import text
+    from core.models import Dish
+
+    with app.app_context():
+        create_all()
+        db = get_session()
+        try:
+            db.execute(text("INSERT INTO sites(id, name, version) VALUES(:i,:n,0) ON CONFLICT(id) DO NOTHING"), {"i": site_id, "n": "Varberg"})
+            db.execute(text("INSERT INTO departments(id, site_id, name, resident_count_mode, resident_count_fixed, version) VALUES(:i,:s,:n,'fixed',0,0) ON CONFLICT(id) DO NOTHING"), {"i": dep_id, "s": site_id, "n": "Avd 2"})
+            db.commit()
+            # Only lunch dishes (no dinner set)
+            d1 = Dish(tenant_id=1, name="Pytt i panna", category=None)
+            db.add(d1)
+            db.commit(); db.refresh(d1)
+            menu = app.menu_service.create_or_get_menu(tenant_id=1, week=week, year=year)
+            app.menu_service.set_variant(tenant_id=1, menu_id=menu.id, day="mon", meal="lunch", variant_type="alt1", dish_id=d1.id)
+        finally:
+            db.close()
+
+    # Ensure weekview materialized
+    r0 = client_admin.get(f"/api/weekview?year={year}&week={week}&department_id={dep_id}", headers=_h("admin"))
+    assert r0.status_code == 200
+
+    r_ui = client_admin.get(
+        f"/ui/weekview?site_id={site_id}&department_id={dep_id}&year={year}&week={week}",
+        headers=_h("admin"),
+    )
+    assert r_ui.status_code == 200
+    html = r_ui.get_data(as_text=True)
+    assert "Vecka" in html and "Avd 2" in html and "Varberg" in html
+    # Dinner columns hidden when no dinner data
+    assert "Middag Alt 1" not in html and "Middag Alt 2" not in html


### PR DESCRIPTION
# Weekview UI Phase 1 — Read-only

Summary
- Adds a server-rendered Weekview (Kommun) page backed by the enriched API.
- Route: `GET /ui/weekview?site_id=...&department_id=...&year=YYYY&week=WW`
- Read-only: menu texts (lunch/dinner + dessert), Alt2 lunch highlight, residents per day.

Changes
- core/ui_blueprint.py
  - New `GET /ui/weekview` endpoint (auth roles: superuser, admin, cook, unit_portal).
  - Validates `year` (2000–2100) and `week` (1–53), resolves `site_name` and `department_name` via DB, then calls `WeekviewService` to fetch the enriched payload.
  - Builds a clean view model: `{site_name, department_name, year, week, has_dinner, days[]}` where each day maps `date`, `weekday_name`, `lunch_alt1|alt2|dessert`, `dinner_alt1|alt2`, `alt2_lunch`, `residents_lunch|residents_dinner`.
  - `has_dinner` computed as any dinner text present across the week; template uses it to conditionally show dinner columns.
- templates/ui/weekview.html
  - Header: `Vecka {{ week }} – {{ department_name }}, {{ site_name }}`.
  - Mon–Sun table with Lunch Alt1/Alt2 (+ Dessert), optional Dinner columns when present, residents shown in a compact style. `.alt2-gul` class marks lunch Alt2 when `alt2_lunch` is true.
  - Minimal, scoped CSS for readability on iPad.
  - Prev/next week navigation via simple links that adjust query parameters.
- tests/ui/test_weekview_ui_phase1.py
  - Seeds a site + department and a week with:
    - Monday lunch alt1/alt2/dessert
    - Tuesday dinner alt1
    - Alt2 flag for Monday
    - Residents for Monday lunch and Tuesday dinner
  - Asserts:
    - Header contains week/site/department
    - Menu texts present
    - `.alt2-gul` appears
    - Dinner columns present when dinner is seeded
  - Bonus test: week without dinner → dinner columns hidden

Notes
- This PR is strictly read-only (no clicks, no changes). It consumes the enriched `GET /api/weekview` service output; Phase 2 will add interactions (marks, Alt2 toggling, residents editing) with ETag handling.
- Error handling: responds 400 on invalid week/year, 404 when site/department not found.

Follow-ups
- Small UI polish (Phase 1.1) based on feedback.
- Phase 2: interactions + ETag/If-Match flows.
